### PR TITLE
Remove keycloak dependency in API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,7 @@
 			<version>4.12.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-spring-boot-starter</artifactId>
-		</dependency>
-
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
@@ -69,19 +65,19 @@
 			<version>1.4.8</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+			<version>2.3.5.RELEASE</version>
+		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.keycloak.bom</groupId>
-				<artifactId>keycloak-adapter-bom</artifactId>
-				<version>11.0.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+
 
 
 	<build>

--- a/src/main/java/io/insee/dev/k8sonboarding/configuration/properties/UiProperties.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/configuration/properties/UiProperties.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Configuration;
 public class UiProperties {
 
     private String clientId;
+    private String keycloakUrl;
+    private String keycloakRealm;
 
     public UiProperties() {
 	super();
@@ -19,6 +21,22 @@ public class UiProperties {
 
     public void setClientId(String clientId) {
 	this.clientId = clientId;
+    }
+
+    public String getKeycloakUrl() {
+        return keycloakUrl;
+    }
+
+    public void setKeycloakUrl(String keycloakUrl) {
+        this.keycloakUrl = keycloakUrl;
+    }
+
+    public String getKeycloakRealm() {
+        return keycloakRealm;
+    }
+
+    public void setKeycloakRealm(String keycloakRealm) {
+        this.keycloakRealm = keycloakRealm;
     }
 
 }

--- a/src/main/java/io/insee/dev/k8sonboarding/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/configuration/security/SecurityConfiguration.java
@@ -1,86 +1,25 @@
 package io.insee.dev.k8sonboarding.configuration.security;
 
-import org.keycloak.adapters.KeycloakConfigResolver;
-import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
-import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
-import org.keycloak.adapters.springsecurity.KeycloakSecurityComponents;
-import org.keycloak.adapters.springsecurity.account.SimpleKeycloakAccount;
-import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
-import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
-import org.keycloak.representations.AccessToken;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Scope;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
-import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
-import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
-import io.insee.dev.k8sonboarding.model.User;
-
-@KeycloakConfiguration
 @EnableWebSecurity
-@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
-public class SecurityConfiguration extends KeycloakWebSecurityConfigurerAdapter {
-
-    @Override
-    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-	return new NullAuthenticatedSessionStrategy();
-    }
-
-    @Bean
-    @Scope(scopeName = WebApplicationContext.SCOPE_REQUEST)
-    public AccessToken getAccessToken() {
-	final AccessToken token = ((SimpleKeycloakAccount) SecurityContextHolder.getContext().getAuthentication()
-		.getDetails()).getKeycloakSecurityContext().getToken();
-	return token;
-    }
-
-    public String getAccessTokenString() {
-	final String token = ((SimpleKeycloakAccount) SecurityContextHolder.getContext().getAuthentication()
-		.getDetails()).getKeycloakSecurityContext().getTokenString();
-	return token;
-    }
-
-    @Bean
-    public UserProvider getUserProvider() {
-	return () -> {
-	    final AccessToken token = getAccessToken();
-	    final User user = new User();
-	    user.setId(token.getPreferredUsername());
-	    user.setAuthToken(getAccessTokenString());
-	    return user;
-	};
-    }
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 	http.httpBasic().disable().csrf().disable()
-		.addFilterBefore(keycloakAuthenticationProcessingFilter(), X509AuthenticationFilter.class)
-		.exceptionHandling().authenticationEntryPoint(authenticationEntryPoint()).and()
-		.addFilterBefore(keycloakPreAuthActionsFilter(), LogoutFilter.class).authorizeRequests()
+	    .authorizeRequests()
 			.antMatchers("/api/public/**").permitAll()
-		.antMatchers("/api/**").authenticated()
-		.anyRequest().permitAll();
-    }
+		    .antMatchers("/api/**").authenticated()
+		    .anyRequest().permitAll()
+		.and()
+			.oauth2ResourceServer()
+			.jwt();
+	}
+	
 
-    @Bean
-    public KeycloakConfigResolver KeycloakConfigResolver() {
-	return new KeycloakSpringBootConfigResolver();
-    }
-
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-	final KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
-	// simple Authority Mapper to avoid ROLE_
-	keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
-	auth.authenticationProvider(keycloakAuthenticationProvider);
-    }
+	
+  
 }

--- a/src/main/java/io/insee/dev/k8sonboarding/configuration/security/UserProvider.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/configuration/security/UserProvider.java
@@ -1,9 +1,11 @@
 package io.insee.dev.k8sonboarding.configuration.security;
 
+import org.springframework.security.core.Authentication;
+
 import io.insee.dev.k8sonboarding.model.User;
 
 @FunctionalInterface
 public interface UserProvider {
 
-    public User getUser();
+    public User getUser(Authentication auth);
 }

--- a/src/main/java/io/insee/dev/k8sonboarding/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/configuration/swagger/SwaggerConfiguration.java
@@ -17,22 +17,22 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 @Configuration
 public class SwaggerConfiguration {
 
-    @Value("${keycloak.auth-server-url}")
-    public String keycloakUrl;
+    @Value("${io.insee.dev.k8sonboarding.swagger.oauth2.authUrl}")
+    public String authUrl;
 
-    @Value("${keycloak.realm}")
-    public String realmName;
+    @Value("${io.insee.dev.k8sonboarding.swagger.oauth2.tokenUrl}")
+    public String tokenUrl;
 
-    public final String SCHEMEKEYCLOAK = "oAuthScheme";
+    public final String SCHEME = "oAuthScheme";
 
     @Bean
-    public OpenAPI customOpenAPIKeycloak() {
+    public OpenAPI customOpenAPIOauth2() {
 	final OpenAPI openapi = createOpenAPI();
-	openapi.components(new Components().addSecuritySchemes(SCHEMEKEYCLOAK, new SecurityScheme()
-		.type(SecurityScheme.Type.OAUTH2).in(SecurityScheme.In.HEADER).description("Authentification keycloak")
+	openapi.components(new Components().addSecuritySchemes(SCHEME, new SecurityScheme()
+		.type(SecurityScheme.Type.OAUTH2).in(SecurityScheme.In.HEADER).description("Authentification Oauth2")
 		.flows(new OAuthFlows().authorizationCode(new OAuthFlow()
-			.authorizationUrl(keycloakUrl + "/realms/" + realmName + "/protocol/openid-connect/auth")
-			.tokenUrl(keycloakUrl + "/realms/" + realmName + "/protocol/openid-connect/token")))));
+			.authorizationUrl(authUrl)
+			.tokenUrl(tokenUrl)))));
 	return openapi;
     }
 
@@ -46,9 +46,9 @@ public class SwaggerConfiguration {
     // permet d'ajouter le header Authorization aux header qui vont bien, ici on
     // l'ajoute que au methode qui ne sont pas sur /api/public/** */
     @Bean
-    public OperationCustomizer ajouterKeycloak() {
+    public OperationCustomizer addSecurity() {
 	return (operation, handlerMethod) -> {
-	    return operation.addSecurityItem(new SecurityRequirement().addList(SCHEMEKEYCLOAK));
+	    return operation.addSecurityItem(new SecurityRequirement().addList(SCHEME));
 	};
     }
 }

--- a/src/main/java/io/insee/dev/k8sonboarding/controller/ClusterAccessController.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/controller/ClusterAccessController.java
@@ -1,11 +1,16 @@
 package io.insee.dev.k8sonboarding.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.insee.dev.k8sonboarding.configuration.security.UserProvider;
+import io.insee.dev.k8sonboarding.model.User;
 import io.insee.dev.k8sonboarding.service.OnboardingService;
 import io.insee.dev.k8sonboarding.view.ClusterCredentials;
 
@@ -19,12 +24,27 @@ public class ClusterAccessController {
     @Autowired
     private UserProvider userProvider;
 
+    @Value("${io.insee.dev.k8sonboarding.jwt.username-claim}")
+	private String usernameClaim;
+
+
     @GetMapping
-    public ClusterCredentials getCredentials() {
-	if (!onboardingService.checkNamespaceExists(userProvider.getUser())) {
-	    onboardingService.onboard(userProvider.getUser());
-	}
-	return onboardingService.getClusterCredentials(userProvider.getUser());
+    public ClusterCredentials getCredentials(Authentication auth) {
+        if (!onboardingService.checkNamespaceExists(userProvider.getUser(auth))) {
+            onboardingService.onboard(userProvider.getUser(auth));
+        }
+        return onboardingService.getClusterCredentials(userProvider.getUser(auth));
+    }
+
+    @Bean
+    public UserProvider getUserProvider() {
+	return auth -> {
+        final User user = new User();
+        Jwt jwt = (Jwt) auth.getPrincipal();
+	    user.setId(jwt.getClaimAsString(usernameClaim));
+	    user.setAuthToken(jwt.getTokenValue());
+	    return user;
+	};
     }
 
 }

--- a/src/main/java/io/insee/dev/k8sonboarding/controller/ConfigurationController.java
+++ b/src/main/java/io/insee/dev/k8sonboarding/controller/ConfigurationController.java
@@ -1,6 +1,5 @@
 package io.insee.dev.k8sonboarding.controller;
 
-import org.keycloak.adapters.springboot.KeycloakSpringBootProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,9 +14,6 @@ import io.insee.dev.k8sonboarding.view.AppConfiguration;
 public class ConfigurationController {
 
     @Autowired
-    KeycloakSpringBootProperties keycloakSpringBootProperties;
-
-    @Autowired
     ClusterProperties clusterProperties;
 
     @Autowired
@@ -25,12 +21,12 @@ public class ConfigurationController {
 
     @GetMapping
     public AppConfiguration getConfiguration() {
-	final AppConfiguration appConfiguration = new AppConfiguration();
-	appConfiguration.setAuthUrl(keycloakSpringBootProperties.getAuthServerUrl());
-	appConfiguration.setRealm(keycloakSpringBootProperties.getRealm());
-	appConfiguration.setResource(keycloakSpringBootProperties.getResource());
-	appConfiguration.setClientId(uiProperties.getClientId());
-	return appConfiguration;
+        final AppConfiguration appConfiguration = new AppConfiguration();
+        appConfiguration.setAuthUrl(uiProperties.getKeycloakUrl());
+        appConfiguration.setRealm(uiProperties.getKeycloakRealm());
+        appConfiguration.setResource(uiProperties.getClientId());
+        appConfiguration.setClientId(uiProperties.getClientId());
+        return appConfiguration;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,5 @@
-keycloak.auth-server-url=
-keycloak.realm=
-keycloak.resource=
-keycloak.bearer-only=true
-keycloak.principal-attribute=preferred_username
+spring.security.oauth2.resourceserver.jwt.issuer-uri=
+
 springdoc.swagger-ui.path=/api
 
 io.insee.dev.k8sonboarding.apiserver-url=https://example.com
@@ -11,3 +8,10 @@ io.insee.dev.k8sonboarding.user-prefix=
 io.insee.dev.k8sonboarding.name-namespace-admin=namespace_admin
 
 io.insee.dev.k8sonboarding.ui.clientId=clientId
+io.insee.dev.k8sonboarding.ui.keycloakUrl=
+io.insee.dev.k8sonboarding.ui.keycloakRealm=
+
+io.insee.dev.k8sonboarding.jwt.username-claim=preferred_username
+
+io.insee.dev.k8sonboarding.swagger.oauth2.authUrl=
+io.insee.dev.k8sonboarding.swagger.oauth2.tokenUrl=


### PR DESCRIPTION
Token validation is done with spring-security oauth2 resource server.

There is still some keycloak specificity left for the UI.